### PR TITLE
fix!: replace markdownSetup with markdown.preamble

### DIFF
--- a/.changeset/wet-donuts-occur.md
+++ b/.changeset/wet-donuts-occur.md
@@ -1,0 +1,13 @@
+---
+"vite-plugin-doctest": major
+---
+
+**Breaking:** Replace `markdownSetup` with `markdown.preamble`.
+
+```ts
+// Before
+doctest({ markdownSetup: 'import path from "node:path";\n' })
+
+// After
+doctest({ markdown: { preamble: 'import path from "node:path";\n' } })
+```

--- a/packages/vite-plugin-doctest/README.md
+++ b/packages/vite-plugin-doctest/README.md
@@ -56,9 +56,9 @@ npx vitest
 
 ### Options
 
-#### markdownSetup
+#### markdown.preamble
 
-Declare top-level setup code for all your markdown files.
+Declare top-level preamble code for all your markdown files.
 Useful for declaring imports without having to pollute code blocks with dynamic imports.
 
 ```ts
@@ -66,9 +66,11 @@ Useful for declaring imports without having to pollute code blocks with dynamic 
 import { defineConfig } from 'vitest/config'; // or `import { defineConfig } from 'vite';`
 import { doctest } from 'vite-plugin-doctest';
 export default defineConfig({
-  plugins: [doctest({ 
-    markdownSetup: `import path from 'node:path';
+  plugins: [doctest({
+    markdown: {
+      preamble: `import path from 'node:path';
 `,
+    },
   })],
   /* ... */
 });

--- a/packages/vite-plugin-doctest/package.json
+++ b/packages/vite-plugin-doctest/package.json
@@ -37,17 +37,18 @@
 	},
 	"homepage": "https://github.com/ssssota/doc-vitest#readme",
 	"peerDependencies": {
-		"vitest": ">=4.1.0",
+		"typescript": ">=5.0.0",
 		"vite": ">=8.0.0",
-		"typescript": ">=5.0.0"
+		"vitest": ">=4.1.0"
 	},
 	"devDependencies": {
+		"@types/node": "^26.1.1",
+		"magic-string": "^0.30.12",
 		"remark-parse": "^11.0.0",
 		"tsup": "^8.5.1",
+		"typescript": "^5.6.3",
 		"unified": "^11.0.5",
 		"vite": "catalog:",
-		"vitest": "catalog:",
-		"magic-string": "^0.30.12",
-		"typescript": "^5.6.3"
+		"vitest": "catalog:"
 	}
 }

--- a/packages/vite-plugin-doctest/src/index.ts
+++ b/packages/vite-plugin-doctest/src/index.ts
@@ -1,6 +1,6 @@
 import type { PluginOption } from "vite";
-import { markdown, typescript } from "./transformers";
 import type { MarkdownTransformOptions } from "./transformers";
+import { markdown, typescript } from "./transformers";
 
 export type Options = {
 	markdown?: MarkdownTransformOptions;

--- a/packages/vite-plugin-doctest/src/index.ts
+++ b/packages/vite-plugin-doctest/src/index.ts
@@ -1,18 +1,22 @@
 import type { PluginOption } from "vite";
 import { markdown, typescript } from "./transformers";
+import type { MarkdownTransformOptions } from "./transformers";
 
-export type Options = { markdownSetup?: string };
+export type Options = {
+	markdown?: MarkdownTransformOptions;
+};
+
 export const doctest = (options: Options = {}): PluginOption => {
 	return {
 		name: "vite-plugin-doctest",
 		enforce: "pre",
+		apply() {
+			if (process.env.VITEST === "true") return true;
+			return false;
+		},
 		transform(code, id) {
-			if (process.env.VITEST !== "true") return code;
 			if (id.match(/\.[cm]?[jt]sx?$/)) return typescript(code, id);
-			if (id.match(/\.md$/))
-				return markdown(code, id, {
-					markdownSetup: options.markdownSetup ?? "",
-				});
+			if (id.match(/\.md$/)) return markdown(code, id, options.markdown);
 		},
 	};
 };

--- a/packages/vite-plugin-doctest/src/transformers/index.ts
+++ b/packages/vite-plugin-doctest/src/transformers/index.ts
@@ -1,2 +1,5 @@
-export { transform as markdown } from "./markdown";
+export {
+	transform as markdown,
+	type MarkdownTransformOptions,
+} from "./markdown";
 export { transform as typescript } from "./typescript";

--- a/packages/vite-plugin-doctest/src/transformers/index.ts
+++ b/packages/vite-plugin-doctest/src/transformers/index.ts
@@ -1,5 +1,5 @@
 export {
-	transform as markdown,
 	type MarkdownTransformOptions,
+	transform as markdown,
 } from "./markdown";
 export { transform as typescript } from "./typescript";

--- a/packages/vite-plugin-doctest/src/transformers/markdown.spec.ts
+++ b/packages/vite-plugin-doctest/src/transformers/markdown.spec.ts
@@ -8,7 +8,7 @@ expect(1 + 1).toBe(2);
 ~~~
 `,
 		"add.ts",
-		{ markdownSetup: "" },
+		{ preamble: "" },
 	);
 
 	expect(code).toMatchInlineSnapshot(`
@@ -17,7 +17,7 @@ expect(1 + 1).toBe(2);
     import.meta.vitest.test("add.ts#0", async () => {
     expect(1 + 1).toBe(2);
     });
-    
+
     }"
   `);
 });
@@ -28,7 +28,7 @@ it("should generate testcode when file ends with closing code fence", async () =
 expect(1 + 1).toBe(2);
 ~~~`,
 		"add.ts",
-		{ markdownSetup: "" },
+		{ preamble: "" },
 	);
 
 	expect(code).toMatchInlineSnapshot(`
@@ -47,7 +47,7 @@ it("should not include @import.meta.vitest in filename", async () => {
 expect(1 + 1).toBe(2);
 ~~~`,
 		"add.ts",
-		{ markdownSetup: "" },
+		{ preamble: "" },
 	);
 
 	expect(code).toMatchInlineSnapshot(`
@@ -67,7 +67,7 @@ expect(1 + 1).toBe(2);
 ~~~
 Extra text`,
 		"add.ts",
-		{ markdownSetup: "" },
+		{ preamble: "" },
 	);
 
 	expect(code).toMatchInlineSnapshot(`

--- a/packages/vite-plugin-doctest/src/transformers/markdown.ts
+++ b/packages/vite-plugin-doctest/src/transformers/markdown.ts
@@ -5,13 +5,16 @@ import { transformWithOxc } from "vite";
 import { vitestExports } from "./utils";
 
 type OxcTransformOptions = NonNullable<Parameters<typeof transformWithOxc>[2]>;
+export type MarkdownTransformOptions = {
+	preamble?: string;
+};
 
 export const transform = async (
 	code: string,
 	id: string,
-	options: { markdownSetup: string },
+	options: MarkdownTransformOptions = {},
 ) => {
-	const { markdownSetup } = options;
+	const { preamble = "" } = options;
 	const ast = unified().use(remarkParse).parse(code);
 	const s = new MagicString(code);
 
@@ -72,7 +75,7 @@ export const transform = async (
 		s.appendLeft(getIndexOfLine(code, l), "//");
 	}
 
-	s.prepend(`${markdownSetup}\
+	s.prepend(`${preamble}\
 if (import.meta.vitest) {
 const {${vitestExports.join(",")}} = import.meta.vitest;\n`);
 	s.append("\n}");

--- a/packages/vite-plugin-doctest/tsconfig.json
+++ b/packages/vite-plugin-doctest/tsconfig.json
@@ -3,6 +3,7 @@
 		"target": "ESNext",
 		"module": "ESNext",
 		"moduleResolution": "bundler",
+		"types": ["node"],
 		"skipLibCheck": true,
 		"strict": true,
 		"outDir": "dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     vite:
       specifier: ^8.0.13
       version: 8.1.4
+    vitest:
+      specifier: ^4.1.0
+      version: 4.1.10
 
 importers:
 
@@ -22,10 +25,13 @@ importers:
         version: 0.7.0
       '@changesets/cli':
         specifier: ^2.27.9
-        version: 2.31.0
+        version: 2.31.0(@types/node@26.1.1)
 
   packages/vite-plugin-doctest:
     devDependencies:
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
       magic-string:
         specifier: ^0.30.12
         version: 0.30.21
@@ -43,10 +49,10 @@ importers:
         version: 11.0.5
       vite:
         specifier: 'catalog:'
-        version: 8.1.4(esbuild@0.27.7)
+        version: 8.1.4(@types/node@26.1.1)(esbuild@0.27.7)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(vite@8.1.4(esbuild@0.27.7))
+        version: 4.1.10(@types/node@26.1.1)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7))
 
   test:
     devDependencies:
@@ -55,16 +61,16 @@ importers:
         version: 14.2.4
       vite:
         specifier: 'catalog:'
-        version: 8.1.4(esbuild@0.27.7)
+        version: 8.1.4(@types/node@26.1.1)(esbuild@0.27.7)
       vite-plugin-doctest:
         specifier: workspace:*
         version: link:../packages/vite-plugin-doctest
       vite-plugin-inspect:
         specifier: ^12.0.2
-        version: 12.0.2(srvx@0.11.15)(typescript@5.9.3)(vite@8.1.4(esbuild@0.27.7))
+        version: 12.0.2(srvx@0.11.15)(typescript@5.9.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(vite@8.1.4(esbuild@0.27.7))
+        version: 4.1.10(@types/node@26.1.1)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7))
 
 packages:
 
@@ -690,6 +696,9 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@26.1.1':
+    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -1911,6 +1920,9 @@ packages:
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -2154,7 +2166,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.31.0':
+  '@changesets/cli@2.31.0(@types/node@26.1.1)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10
@@ -2170,7 +2182,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3
+      '@inquirer/external-editor': 1.0.3(@types/node@26.1.1)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -2380,10 +2392,12 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@inquirer/external-editor@1.0.3':
+  '@inquirer/external-editor@1.0.3(@types/node@26.1.1)':
     dependencies:
       chardet: 2.2.0
       iconv-lite: 0.7.3
+    optionalDependencies:
+      '@types/node': 26.1.1
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -2609,19 +2623,23 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
+  '@types/node@26.1.1':
+    dependencies:
+      undici-types: 8.3.0
+
   '@types/unist@3.0.3': {}
 
   '@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@5.9.3))':
     dependencies:
       valibot: 1.4.2(typescript@5.9.3)
 
-  '@vitejs/devtools-kit@0.4.1(srvx@0.11.15)(typescript@5.9.3)(vite@8.1.4(esbuild@0.27.7))':
+  '@vitejs/devtools-kit@0.4.1(srvx@0.11.15)(typescript@5.9.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7))':
     dependencies:
       '@devframes/hub': 0.6.2(devframe@0.6.2(srvx@0.11.15)(typescript@5.9.3))
       devframe: 0.6.2(srvx@0.11.15)(typescript@5.9.3)
       mlly: 1.8.2
       nostics: 1.1.4
-      vite: 8.1.4(esbuild@0.27.7)
+      vite: 8.1.4(@types/node@26.1.1)(esbuild@0.27.7)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - srvx
@@ -2636,13 +2654,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.1.4(esbuild@0.27.7))':
+  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.4(esbuild@0.27.7)
+      vite: 8.1.4(@types/node@26.1.1)(esbuild@0.27.7)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -3834,6 +3852,8 @@ snapshots:
 
   ufo@1.6.4: {}
 
+  undici-types@8.3.0: {}
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -3880,9 +3900,9 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-plugin-inspect@12.0.2(srvx@0.11.15)(typescript@5.9.3)(vite@8.1.4(esbuild@0.27.7)):
+  vite-plugin-inspect@12.0.2(srvx@0.11.15)(typescript@5.9.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7)):
     dependencies:
-      '@vitejs/devtools-kit': 0.4.1(srvx@0.11.15)(typescript@5.9.3)(vite@8.1.4(esbuild@0.27.7))
+      '@vitejs/devtools-kit': 0.4.1(srvx@0.11.15)(typescript@5.9.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7))
       ansis: 4.3.1
       error-stack-parser-es: 2.0.1
       obug: 2.1.3
@@ -3891,13 +3911,13 @@ snapshots:
       perfect-debounce: 2.1.0
       sirv: 3.0.2
       unplugin-utils: 0.3.2
-      vite: 8.1.4(esbuild@0.27.7)
+      vite: 8.1.4(@types/node@26.1.1)(esbuild@0.27.7)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - srvx
       - typescript
 
-  vite@8.1.4(esbuild@0.27.7):
+  vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -3905,13 +3925,14 @@ snapshots:
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
+      '@types/node': 26.1.1
       esbuild: 0.27.7
       fsevents: 2.3.3
 
-  vitest@4.1.10(vite@8.1.4(esbuild@0.27.7)):
+  vitest@4.1.10(@types/node@26.1.1)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.4(esbuild@0.27.7))
+      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -3928,8 +3949,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.4(esbuild@0.27.7)
+      vite: 8.1.4(@types/node@26.1.1)(esbuild@0.27.7)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.1.1
     transitivePeerDependencies:
       - msw
 

--- a/test/src/test.md
+++ b/test/src/test.md
@@ -40,7 +40,7 @@ const { add } = await import("./add");
 assert(add(1, 2) === 3);
 ```
 
-Or via a static import in the `markdownSetup` option:
+Or via a static import in the `markdown.preamble` option:
 
 ```js @import.meta.vitest
 // `sub` import is declared in vitest.config.ts

--- a/test/vitest.config.ts
+++ b/test/vitest.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	plugins: [
 		Inspect({ build: true, outputDir: ".vite-inspect" }),
-		doctest({ markdownSetup: 'import { sub } from "./sub";\n' }),
+		doctest({ markdown: { preamble: 'import { sub } from "./sub";\n' } }),
 	],
 	test: {
 		includeSource: ["./src/**/*.[jt]s", "./src/**/*.md"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed the doctest Markdown configuration option from `markdownSetup` to `markdown.preamble`.
  * Updated Markdown preamble configuration to use the nested `markdown` option.
  * Added the `MarkdownTransformOptions` type for configuring Markdown transformations.

* **Documentation**
  * Updated configuration examples and testing documentation to reflect the new option name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->